### PR TITLE
ci: for the time being, latest node build is deactivated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 'node'
   - '8'
 install:
   - npm install


### PR DESCRIPTION
This issue is related to the dependency nodegit. Related issue is https://github.com/nodegit/nodegit/issues/1490